### PR TITLE
Add LIDI to useful link

### DIFF
--- a/external_content.md
+++ b/external_content.md
@@ -31,6 +31,7 @@ https://github.com/ypo/flute
 High-speed data diode software developed in rust by the French cybersecurity agency, with raptorq error correction.
 
 https://github.com/ANSSI-FR/lidi
+
 Documentation: https://anssi-fr.github.io/lidi/
 
 ## UDPcast as a service

--- a/external_content.md
+++ b/external_content.md
@@ -27,6 +27,11 @@ Massively scalable multicast distribution solution
 The library implements a unidirectional file delivery, without the need of a return channel.
 https://github.com/ypo/flute 
 
+### LIDI - Transfer a raw TCP or Unix stream or files through a unidirectional link with forward error correction 
+High-speed data diode software developed in rust by the French cybersecurity agency, with raptorq error correction.
+
+https://github.com/ANSSI-FR/lidi
+Documentation: https://anssi-fr.github.io/lidi/
 
 ## UDPcast as a service
 


### PR DESCRIPTION
Hello, 

I suggest adding this repository to the list of useful links. LIDI implements to copy TCP streams (or files) across a unidirectional link fast and reliably. Unfortunately, the repository doesn't seem to be very active, but through your visibility, it could gain in popularity and attract contributors to fix bugs and improve the code.
